### PR TITLE
US616155: Various updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
         <artifactId>worker-message-prioritization-target-capacity-calculators</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+          <groupId>net.jodah</groupId>
+          <artifactId>expiringmap</artifactId>
+          <version>0.5.10</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,6 @@
         <artifactId>worker-message-prioritization-target-capacity-calculators</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <dependency>
-          <groupId>net.jodah</groupId>
-          <artifactId>expiringmap</artifactId>
-          <version>0.5.10</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/worker-message-prioritization-distribution-container/README.md
+++ b/worker-message-prioritization-distribution-container/README.md
@@ -7,6 +7,10 @@ This repository consists of the source to build a container that includes the
 
 ### Environment Variables
 
+* `CAF_RABBITMQ_VHOST`  
+    **Default**: `/`  
+    **Description**: The RabbitMQ virtual host.
+
 * `CAF_RABBITMQ_HOST`  
     **Default**: `rabbitmq`  
     **Description**: The RabbitMQ host.
@@ -34,3 +38,16 @@ This repository consists of the source to build a container that includes the
 * `CAF_RABBITMQ_MGMT_PASSWORD`  
     **Default**: `guest`  
     **Description**: The RabbitMQ management API password.
+
+* `CAF_WMP_DISTRIBUTOR_RUN_INTERVAL_MILLISECONDS`  
+    **Default**: `10000`  
+    **Description**: How often the distributor runs.
+
+* `CAF_WMP_NON_RUNNING_SHOVEL_TIMEOUT_MILLISECONDS`  
+    **Default**: `120000`  
+    **Description**: The timeout in milliseconds after which to delete RabbitMQ shovels that are in a bad state (i.e. not 'running').
+
+* `CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS`  
+    **Default**: `120000`  
+    **Description**: How often to check for non-running RabbitMQ shovels.
+

--- a/worker-message-prioritization-distribution-container/README.md
+++ b/worker-message-prioritization-distribution-container/README.md
@@ -45,7 +45,9 @@ This repository consists of the source to build a container that includes the
 
 * `CAF_WMP_NON_RUNNING_SHOVEL_TIMEOUT_MILLISECONDS`  
     **Default**: `120000`  
-    **Description**: The timeout in milliseconds after which to delete RabbitMQ shovels that are in a bad state (i.e. not 'running').
+    **Description**: The timeout in milliseconds after which to delete RabbitMQ shovels that are in a bad state (i.e. not 'running'). The
+    timeout begins from the time this application first observed the shovel in a bad state, which will depend on how often the shovel
+    state check runs (the `CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS` environment variable).
 
 * `CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS`  
     **Default**: `120000`  

--- a/worker-message-prioritization-distribution-container/pom.xml
+++ b/worker-message-prioritization-distribution-container/pom.xml
@@ -141,10 +141,16 @@
                     <verbose>true</verbose>
                     <images>
 
-                        <!-- Run the RabbitMQ image -->
+                        <!-- Build a RabbitMQ image with the shovel plugins enabled for testing purposes -->
                         <image>
                             <alias>rabbitmq</alias>
-                            <name>${dockerHubPublic}/library/rabbitmq:3-management</name>
+                            <name>dev/rabbitmq-with-shovel-plugin</name>
+                            <build>
+                                <dockerFile>${project.basedir}/src/test/docker/Dockerfile</dockerFile>
+                                <args>
+                                    <RABBITMQ_IMAGE>${dockerHubPublic}/library/rabbitmq:3-management</RABBITMQ_IMAGE>
+                                </args>
+                            </build>
                             <run>
                                 <ports>
                                     <port>${rabbitmq.ctrl.port}:15672</port>

--- a/worker-message-prioritization-distribution-container/pom.xml
+++ b/worker-message-prioritization-distribution-container/pom.xml
@@ -144,7 +144,7 @@
                         <!-- Build a RabbitMQ image with the shovel plugins enabled for testing purposes -->
                         <image>
                             <alias>rabbitmq</alias>
-                            <name>${project.artifactId}-test-rabbitmq-with-shovel-plugin:${project.version}</name>
+                            <name>${dockerWorkerFrameworkOrg}test-rabbitmq-with-shovel-plugin:${project.version}</name>
                             <build>
                                 <dockerFile>${project.basedir}/src/test/docker/Dockerfile</dockerFile>
                                 <args>

--- a/worker-message-prioritization-distribution-container/pom.xml
+++ b/worker-message-prioritization-distribution-container/pom.xml
@@ -144,7 +144,7 @@
                         <!-- Build a RabbitMQ image with the shovel plugins enabled for testing purposes -->
                         <image>
                             <alias>rabbitmq</alias>
-                            <name>dev/rabbitmq-with-shovel-plugin</name>
+                            <name>${project.artifactId}-test-rabbitmq-with-shovel-plugin:${project.version}</name>
                             <build>
                                 <dockerFile>${project.basedir}/src/test/docker/Dockerfile</dockerFile>
                                 <args>

--- a/worker-message-prioritization-distribution-container/pom.xml
+++ b/worker-message-prioritization-distribution-container/pom.xml
@@ -131,6 +131,9 @@
                         <goals>
                             <goal>push</goal>
                         </goals>
+                        <configuration>
+                            <filter>worker-message-prioritization-distribution</filter>
+                        </configuration>
                     </execution>
 
                 </executions>
@@ -171,6 +174,7 @@
                         </image>
 
                         <image>
+                            <alias>worker-message-prioritization-distribution</alias>
                             <name>${dockerWorkerFrameworkOrg}worker-message-prioritization-distribution${dockerProjectVersion}</name>
                             <!-- Build the image for this module -->
                             <build>

--- a/worker-message-prioritization-distribution-container/src/test/docker/Dockerfile
+++ b/worker-message-prioritization-distribution-container/src/test/docker/Dockerfile
@@ -1,0 +1,19 @@
+#
+# Copyright 2022-2023 Micro Focus or one of its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG RABBITMQ_IMAGE
+FROM $RABBITMQ_IMAGE
+RUN rabbitmq-plugins enable --offline rabbitmq_shovel rabbitmq_shovel_management

--- a/worker-message-prioritization-distribution-container/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorIT.java
+++ b/worker-message-prioritization-distribution-container/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorIT.java
@@ -27,7 +27,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.TimeoutException;
 
-public final class LowLevelDistributorIT extends DistributorTestBase {
+// This test will used whatever distributor implementation (low level or shovel) has been set as the mainClass in the maven-jar-plugin in
+// worker-message-prioritization-distribution/pom.xml.
+public final class DistributorIT extends DistributorTestBase {
 
     @Test
     public void twoStagingQueuesTest() throws TimeoutException, IOException, InterruptedException {

--- a/worker-message-prioritization-distribution/pom.xml
+++ b/worker-message-prioritization-distribution/pom.xml
@@ -182,7 +182,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>com.github.workerframework.workermessageprioritization.redistribution.lowlevel.LowLevelApplication</mainClass>
+                            <mainClass>com.github.workerframework.workermessageprioritization.redistribution.shovel.ShovelApplication</mainClass>
                         </manifest>
                     </archive>
                 </configuration>

--- a/worker-message-prioritization-distribution/pom.xml
+++ b/worker-message-prioritization-distribution/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>amqp-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>expiringmap</artifactId>
+        </dependency>
+        <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/worker-message-prioritization-distribution/pom.xml
+++ b/worker-message-prioritization-distribution/pom.xml
@@ -61,10 +61,6 @@
             <artifactId>amqp-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.jodah</groupId>
-            <artifactId>expiringmap</artifactId>
-        </dependency>
-        <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/MessageDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/MessageDistributor.java
@@ -53,12 +53,12 @@ public abstract class MessageDistributor {
                             q.getMessages() > 0 &&
                                     q.getName().startsWith(targetQueue.getName() + LOAD_BALANCED_INDICATOR))
                     .collect(Collectors.toSet());
-
-            LOGGER.debug("Filtered the list of queues from the RabbitMQ API to contain only the staging queues: {}", stagingQueues);
             
             if(stagingQueues.isEmpty()) {
                 continue;
             }
+            
+            LOGGER.debug("Creating a new DistributorWorkItem for target queue: {} and staging queues: {}", targetQueue, stagingQueues);
             
             distributorWorkItems.add(new DistributorWorkItem(targetQueue, stagingQueues));
             

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/config/MessageDistributorConfig.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/config/MessageDistributorConfig.java
@@ -20,6 +20,9 @@ import com.google.common.base.Strings;
 
 public final class MessageDistributorConfig {
 
+    private static final String CAF_RABBITMQ_VHOST = "CAF_RABBITMQ_VHOST";
+    private static final String CAF_RABBITMQ_VHOST_DEFAULT = "/";
+
     private static final String CAF_RABBITMQ_HOST = "CAF_RABBITMQ_HOST";
     private static final String CAF_RABBITMQ_HOST_DEFAULT = "rabbitmq";
 
@@ -41,6 +44,20 @@ public final class MessageDistributorConfig {
     private static final String CAF_RABBITMQ_MGMT_PASSWORD = "CAF_RABBITMQ_MGMT_PASSWORD";
     private static final String CAF_RABBITMQ_MGMT_PASSWORD_DEFAULT = "guest";
 
+    private static final String CAF_WMP_DISTRIBUTOR_RUN_INTERVAL_MILLISECONDS = "CAF_WMP_DISTRIBUTOR_RUN_INTERVAL_MILLISECONDS";
+    private static final long CAF_WMP_DISTRIBUTOR_RUN_INTERVAL_MILLISECONDS_DEFAULT = 10000;
+
+    private static final String CAF_WMP_NON_RUNNING_SHOVEL_TIMEOUT_MILLISECONDS
+        = "CAF_WMP_NON_RUNNING_SHOVEL_TIMEOUT_MILLISECONDS";
+    private static final long CAF_WMP_NON_RUNNING_SHOVEL_TIMEOUT_MILLISECONDS_DEFAULT
+        = 120000;
+
+    private static final String CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS
+        = "CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS";
+    private static final long CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS_DEFAULT
+        = 120000;
+
+    private final String rabbitMQVHost;
     private final String rabbitMQHost;
     private final int rabbitMQPort;
     private final String rabbitMQUsername;
@@ -48,16 +65,33 @@ public final class MessageDistributorConfig {
     private final String rabbitMQMgmtUrl;
     private final String rabbitMQMgmtUsername;
     private final String rabbitMQMgmtPassword;
+    private final long distributorRunIntervalMilliseconds;
+    private final long nonRunningShovelTimeoutMilliseconds;
+    private final long nonRunningShovelCheckIntervalMilliseconds;
 
     public MessageDistributorConfig() {
+        rabbitMQVHost = getEnvOrDefault(CAF_RABBITMQ_VHOST, CAF_RABBITMQ_VHOST_DEFAULT);
         rabbitMQHost = getEnvOrDefault(CAF_RABBITMQ_HOST, CAF_RABBITMQ_HOST_DEFAULT);
         rabbitMQPort = getEnvOrDefault(CAF_RABBITMQ_PORT, CAF_RABBITMQ_PORT_DEFAULT);
         rabbitMQUsername = getEnvOrDefault(CAF_RABBITMQ_USERNAME, CAF_RABBITMQ_USERNAME_DEFAULT);
         rabbitMQPassword = getEnvOrDefault(CAF_RABBITMQ_PASSWORD, CAF_RABBITMQ_PASSWORD_DEFAULT);
-
         rabbitMQMgmtUrl = getEnvOrDefault(CAF_RABBITMQ_MGMT_URL, CAF_RABBITMQ_MGMT_URL_DEFAULT);
         rabbitMQMgmtUsername = getEnvOrDefault(CAF_RABBITMQ_MGMT_USERNAME, CAF_RABBITMQ_MGMT_USERNAME_DEFAULT);
         rabbitMQMgmtPassword = getEnvOrDefault(CAF_RABBITMQ_MGMT_PASSWORD, CAF_RABBITMQ_MGMT_PASSWORD_DEFAULT);
+        distributorRunIntervalMilliseconds = getEnvOrDefault(
+            CAF_WMP_DISTRIBUTOR_RUN_INTERVAL_MILLISECONDS,
+            CAF_WMP_DISTRIBUTOR_RUN_INTERVAL_MILLISECONDS_DEFAULT);
+        nonRunningShovelTimeoutMilliseconds = getEnvOrDefault(
+            CAF_WMP_NON_RUNNING_SHOVEL_TIMEOUT_MILLISECONDS,
+            CAF_WMP_NON_RUNNING_SHOVEL_TIMEOUT_MILLISECONDS_DEFAULT);
+        nonRunningShovelCheckIntervalMilliseconds = getEnvOrDefault(
+            CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS,
+            CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS_DEFAULT
+    );
+    }
+
+    public String getRabbitMQVHost() {
+        return rabbitMQVHost;
     }
 
     public String getRabbitMQHost() {
@@ -88,9 +122,22 @@ public final class MessageDistributorConfig {
         return rabbitMQMgmtPassword;
     }
 
+    public long getNonRunningShovelTimeoutMilliseconds() {
+        return nonRunningShovelTimeoutMilliseconds;
+    }
+
+    public long getNonRunningShovelCheckIntervalMilliseconds() {
+        return nonRunningShovelCheckIntervalMilliseconds;
+    }
+
+    public long getDistributorRunIntervalMilliseconds() {
+        return distributorRunIntervalMilliseconds;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
+            .add(CAF_RABBITMQ_VHOST, rabbitMQVHost)
             .add(CAF_RABBITMQ_HOST, rabbitMQHost)
             .add(CAF_RABBITMQ_PORT, rabbitMQPort)
             .add(CAF_RABBITMQ_USERNAME, rabbitMQUsername)
@@ -98,6 +145,9 @@ public final class MessageDistributorConfig {
             .add(CAF_RABBITMQ_MGMT_URL, rabbitMQMgmtUrl)
             .add(CAF_RABBITMQ_MGMT_USERNAME, rabbitMQMgmtUsername)
             .add(CAF_RABBITMQ_MGMT_PASSWORD, "<HIDDEN>")
+            .add(CAF_WMP_DISTRIBUTOR_RUN_INTERVAL_MILLISECONDS, distributorRunIntervalMilliseconds)
+            .add(CAF_WMP_NON_RUNNING_SHOVEL_TIMEOUT_MILLISECONDS, nonRunningShovelTimeoutMilliseconds)
+            .add(CAF_WMP_NON_RUNNING_SHOVEL_CHECK_INTERVAL_MILLISECONDS, nonRunningShovelCheckIntervalMilliseconds)
             .toString();
     }
 
@@ -111,5 +161,11 @@ public final class MessageDistributorConfig {
         final String value = System.getenv(name);
 
         return !Strings.isNullOrEmpty(value) ? Integer.parseInt(value) : defaultValue;
+    }
+    
+    private static long getEnvOrDefault(final String name, final long defaultValue) {
+        final String value = System.getenv(name);
+
+        return !Strings.isNullOrEmpty(value) ? Long.parseLong(value) : defaultValue;
     }
 }

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/lowlevel/LowLevelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/lowlevel/LowLevelDistributor.java
@@ -41,11 +41,13 @@ public class LowLevelDistributor extends MessageDistributor {
     private final StagingTargetPairProvider stagingTargetPairProvider;
     private final ConnectionFactory connectionFactory;
     private final String connectionDetails;
+    private final long distributorRunIntervalMilliseconds;
 
     public LowLevelDistributor(final RabbitManagementApi<QueuesApi> queuesApi,
                                final ConnectionFactory connectionFactory,
                                final ConsumptionTargetCalculator consumptionTargetCalculator,
-                               final StagingTargetPairProvider stagingTargetPairProvider) {
+                               final StagingTargetPairProvider stagingTargetPairProvider,
+                               final long distributorRunIntervalMilliseconds) {
         super(queuesApi);
         this.connectionFactory = connectionFactory;
         this.connectionDetails = String.format(
@@ -56,6 +58,7 @@ public class LowLevelDistributor extends MessageDistributor {
             connectionFactory.isSSL());
         this.consumptionTargetCalculator = consumptionTargetCalculator;
         this.stagingTargetPairProvider = stagingTargetPairProvider;
+        this.distributorRunIntervalMilliseconds = distributorRunIntervalMilliseconds;
     }
     
     public void run() throws IOException, TimeoutException, InterruptedException {
@@ -68,7 +71,7 @@ public class LowLevelDistributor extends MessageDistributor {
                 runOnce(connection);
 
                 try {
-                    Thread.sleep(1000 * 10);
+                    Thread.sleep(distributorRunIntervalMilliseconds);
                 } catch (final InterruptedException e) {
                     LOGGER.warn("Interrupted {}", e.getMessage());
                     throw e;

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelApplication.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelApplication.java
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.workerframework.workermessageprioritization.redistribution.lowlevel;
+package com.github.workerframework.workermessageprioritization.redistribution.shovel;
 
 import com.github.workerframework.workermessageprioritization.redistribution.consumption.EqualConsumptionTargetCalculator;
 import com.github.workerframework.workermessageprioritization.rabbitmq.QueuesApi;
 import com.github.workerframework.workermessageprioritization.rabbitmq.RabbitManagementApi;
+import com.github.workerframework.workermessageprioritization.rabbitmq.ShovelsApi;
 import com.github.workerframework.workermessageprioritization.redistribution.config.MessageDistributorConfig;
+import com.github.workerframework.workermessageprioritization.redistribution.consumption.ConsumptionTargetCalculator;
 import com.github.workerframework.workermessageprioritization.targetcapacitycalculators.FixedTargetQueueCapacityProvider;
 import com.rabbitmq.client.ConnectionFactory;
 
@@ -27,12 +29,12 @@ import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LowLevelApplication {
-    
-    private static final Logger LOGGER = LoggerFactory.getLogger(LowLevelApplication.class);
+public class ShovelApplication
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShovelApplication.class);
 
-    public static void main(String[] args) throws IOException, TimeoutException, InterruptedException {
-
+    public static void main(String[] args) throws IOException, TimeoutException, InterruptedException
+    {
         final ConnectionFactory connectionFactory = new ConnectionFactory();
 
         final MessageDistributorConfig messageDistributorConfig = new MessageDistributorConfig();
@@ -43,10 +45,7 @@ public class LowLevelApplication {
         connectionFactory.setUsername(messageDistributorConfig.getRabbitMQUsername());
         connectionFactory.setPassword(messageDistributorConfig.getRabbitMQPassword());
         connectionFactory.setPort(messageDistributorConfig.getRabbitMQPort());
-        connectionFactory.setVirtualHost("/");
-
-        //https://www.rabbitmq.com/api-guide.html#java-nio
-        //connectionFactory.useNio();
+        connectionFactory.setVirtualHost(messageDistributorConfig.getRabbitMQVHost());
 
         final RabbitManagementApi<QueuesApi> queuesApi = new RabbitManagementApi<>(
             QueuesApi.class,
@@ -54,14 +53,25 @@ public class LowLevelApplication {
             messageDistributorConfig.getRabbitMQMgmtUsername(),
             messageDistributorConfig.getRabbitMQMgmtPassword());
 
-        final LowLevelDistributor lowLevelDistributor =
-                new LowLevelDistributor(
-                        queuesApi,
-                        connectionFactory,
-                        new EqualConsumptionTargetCalculator(new FixedTargetQueueCapacityProvider()),
-                        new StagingTargetPairProvider(),
-                        messageDistributorConfig.getDistributorRunIntervalMilliseconds());
+        RabbitManagementApi<ShovelsApi> shovelsApi = new RabbitManagementApi<>(
+            ShovelsApi.class,
+            messageDistributorConfig.getRabbitMQMgmtUrl(),
+            messageDistributorConfig.getRabbitMQMgmtUsername(),
+            messageDistributorConfig.getRabbitMQMgmtPassword());
 
-        lowLevelDistributor.run();
+        final ConsumptionTargetCalculator consumptionTargetCalculator
+            = new EqualConsumptionTargetCalculator(new FixedTargetQueueCapacityProvider());
+
+        final ShovelDistributor shovelDistributor = new ShovelDistributor(
+            queuesApi,
+            shovelsApi,
+            consumptionTargetCalculator,
+            messageDistributorConfig.getRabbitMQUsername(),
+            messageDistributorConfig.getRabbitMQVHost(),
+            messageDistributorConfig.getNonRunningShovelTimeoutMilliseconds(),
+            messageDistributorConfig.getNonRunningShovelCheckIntervalMilliseconds(),
+            messageDistributorConfig.getDistributorRunIntervalMilliseconds());
+
+        shovelDistributor.run();
     }
 }

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelApplication.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelApplication.java
@@ -33,7 +33,7 @@ public class ShovelApplication
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ShovelApplication.class);
 
-    public static void main(String[] args) throws IOException, TimeoutException, InterruptedException
+    public static void main(String[] args) throws IOException, InterruptedException
     {
         final ConnectionFactory connectionFactory = new ConnectionFactory();
 

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
@@ -25,32 +25,65 @@ import com.github.workerframework.workermessageprioritization.rabbitmq.Retrieved
 import com.github.workerframework.workermessageprioritization.rabbitmq.Shovel;
 import com.github.workerframework.workermessageprioritization.rabbitmq.ShovelsApi;
 import com.github.workerframework.workermessageprioritization.redistribution.DistributorWorkItem;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class ShovelDistributor extends MessageDistributor {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(ShovelDistributor.class);
+    
+    private static final String ACK_MODE = "on-confirm";
+
     private final RabbitManagementApi<ShovelsApi> shovelsApi;
     private final ConsumptionTargetCalculator consumptionTargetCalculator;
+    private final String rabbitMQVHost;
+    private final String rabbitMQUri;
+    private final long distributorRunIntervalMilliseconds;
 
     public ShovelDistributor(
             final RabbitManagementApi<QueuesApi> queuesApi,
             final RabbitManagementApi<ShovelsApi> shovelsApi,
-            final ConsumptionTargetCalculator consumptionTargetCalculator) {
+            final ConsumptionTargetCalculator consumptionTargetCalculator,
+            final String rabbitMQUsername,
+            final String rabbitMQVHost,
+            final long nonRunningShovelTimeoutMilliseconds,
+            final long nonRunningShovelTimeoutCheckIntervalMilliseconds,
+            final long distributorRunIntervalMilliseconds) throws UnsupportedEncodingException {
 
         super(queuesApi);
         this.shovelsApi = shovelsApi;
         this.consumptionTargetCalculator = consumptionTargetCalculator;
+        this.rabbitMQVHost = rabbitMQVHost;
+        this.rabbitMQUri = String.format(
+            "amqp://%s@/%s", rabbitMQUsername, URLEncoder.encode(this.rabbitMQVHost, StandardCharsets.UTF_8.toString()));
+        this.distributorRunIntervalMilliseconds = distributorRunIntervalMilliseconds;
+
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
+            new ShovelStateChecker(shovelsApi, rabbitMQVHost, nonRunningShovelTimeoutMilliseconds),
+            0,
+            nonRunningShovelTimeoutCheckIntervalMilliseconds,
+            TimeUnit.MILLISECONDS);
     }
     
-    public void run() {
+    public void run() throws InterruptedException {
         while(true) {
             runOnce();
+
+            try {
+                Thread.sleep(distributorRunIntervalMilliseconds);
+            } catch (final InterruptedException e) {
+                LOGGER.warn("Interrupted {}", e.getMessage());
+                throw e;
+            }
         }
     }
     
@@ -59,6 +92,8 @@ public class ShovelDistributor extends MessageDistributor {
         final Set<DistributorWorkItem> distributorWorkItems = getDistributorWorkItems();
         
         final List<RetrievedShovel> retrievedShovels = shovelsApi.getApi().getShovels();
+        
+        LOGGER.debug("Read the following list of shovels from the RabbitMQ API: {}", retrievedShovels);
         
         for(final DistributorWorkItem distributorWorkItem : distributorWorkItems) {
             
@@ -82,27 +117,36 @@ public class ShovelDistributor extends MessageDistributor {
                             .endsWith(queueConsumptionTarget.getKey().getName()))) {
                         LOGGER.info("Shovel {} already exists, ignoring.", queueConsumptionTarget.getKey().getName());
                     } else {
+                        // Delete this shovel after all the messages in the staging queue have been consumed OR we have reached the
+                        // maximum amount of messages we are allowed to consume from the staging queue (whichever is lower).
+                        // This ensures the shovel is always deleted.
+                        final long numMessagesInStagingQueue = queueConsumptionTarget.getKey().getMessages();
+                        final long maxNumMessagesToConsumeFromStagingQueue = queueConsumptionTarget.getValue();
+                        final long srcDeleteAfter = Math.min(numMessagesInStagingQueue, maxNumMessagesToConsumeFromStagingQueue);
+ 
+                        final String stagingQueue = queueConsumptionTarget.getKey().getName();
+                        final String targetQueue = distributorWorkItem.getTargetQueue().getName();
+
                         final Shovel shovel = new Shovel();
-//                        shovel.setSrcDeleteAfter(100);
-                        shovel.setSrcDeleteAfter((int)queueConsumptionTarget.getKey().getMessages());
-                        shovel.setAckMode("on-confirm");
-                        shovel.setSrcQueue(queueConsumptionTarget.getKey().getName());
-                        shovel.setSrcUri("amqp://");
-                        shovel.setDestQueue(distributorWorkItem.getTargetQueue().getName());
-                        shovel.setDestUri("amqp://");
+                        shovel.setSrcDeleteAfter(srcDeleteAfter);
+                        shovel.setAckMode(ACK_MODE);
+                        shovel.setSrcQueue(stagingQueue);
+                        shovel.setSrcUri(rabbitMQUri);
+                        shovel.setDestQueue(targetQueue);
+                        shovel.setDestUri(rabbitMQUri);
 
-                        LOGGER.info("Creating shovel {} to consume {} messages.", 
-                                queueConsumptionTarget.getKey().getName(), 
-                                queueConsumptionTarget.getKey().getMessages());
+                        LOGGER.info("Creating shovel named {} with properties {} to consume {} messages",
+                                    stagingQueue,
+                                    shovel,
+                                    srcDeleteAfter);
 
-                        shovelsApi.getApi().putShovel("/", queueConsumptionTarget.getKey().getName(),
-                                new Component<>("shovel",
-                                        queueConsumptionTarget.getKey().getName(),
-                                        shovel));
+                        shovelsApi.getApi().putShovel(rabbitMQVHost, stagingQueue,
+                                                      new Component<>("shovel",
+                                                                      stagingQueue,
+                                                                      shovel));                      
                     }
                 }
-            }            
-            
+            }
         }
         
     }

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
@@ -28,6 +28,8 @@ import com.github.workerframework.workermessageprioritization.redistribution.Dis
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +46,7 @@ public class ShovelDistributor extends MessageDistributor {
     private static final String ACK_MODE = "on-confirm";
 
     private final RabbitManagementApi<ShovelsApi> shovelsApi;
+    private final Map<String, Instant> shovelNameToCreationTimeUTC;
     private final ConsumptionTargetCalculator consumptionTargetCalculator;
     private final String rabbitMQVHost;
     private final String rabbitMQUri;
@@ -61,6 +64,7 @@ public class ShovelDistributor extends MessageDistributor {
 
         super(queuesApi);
         this.shovelsApi = shovelsApi;
+        this.shovelNameToCreationTimeUTC = new HashMap<>();
         this.consumptionTargetCalculator = consumptionTargetCalculator;
         this.rabbitMQVHost = rabbitMQVHost;
         this.rabbitMQUri = String.format(
@@ -68,7 +72,7 @@ public class ShovelDistributor extends MessageDistributor {
         this.distributorRunIntervalMilliseconds = distributorRunIntervalMilliseconds;
 
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-            new ShovelStateChecker(shovelsApi, rabbitMQVHost, nonRunningShovelTimeoutMilliseconds),
+            new ShovelStateChecker(shovelsApi, shovelNameToCreationTimeUTC, rabbitMQVHost, nonRunningShovelTimeoutMilliseconds),
             0,
             nonRunningShovelTimeoutCheckIntervalMilliseconds,
             TimeUnit.MILLISECONDS);
@@ -143,7 +147,13 @@ public class ShovelDistributor extends MessageDistributor {
                         shovelsApi.getApi().putShovel(rabbitMQVHost, stagingQueue,
                                                       new Component<>("shovel",
                                                                       stagingQueue,
-                                                                      shovel));                      
+                                                                      shovel));
+
+                        // Although we can get the shovel creation time from the RabbitMQ Shovel API, it is returned in
+                        // 'local calendar time' (https://www.rabbitmq.com/shovel.html), so we cannot be certain what timezone it is
+                        // using, which will make later calculations using this time possibly inaccurate.
+                        // To avoid this, we are recording the shovel creation time here in UTC.
+                        shovelNameToCreationTimeUTC.put(stagingQueue, Instant.now());
                     }
                 }
             }

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
@@ -29,6 +29,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import net.jodah.expiringmap.ExpiringMap;
 
 public class ShovelDistributor extends MessageDistributor {
     
@@ -64,9 +64,7 @@ public class ShovelDistributor extends MessageDistributor {
 
         super(queuesApi);
         this.shovelsApi = shovelsApi;
-        this.shovelNameToCreationTimeUTC = ExpiringMap.builder()
-            .expiration(24, TimeUnit.HOURS)
-            .build();
+        this.shovelNameToCreationTimeUTC = new HashMap<>();
         this.consumptionTargetCalculator = consumptionTargetCalculator;
         this.rabbitMQVHost = rabbitMQVHost;
         this.rabbitMQUri = String.format(

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
@@ -29,7 +29,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import net.jodah.expiringmap.ExpiringMap;
 
 public class ShovelDistributor extends MessageDistributor {
     
@@ -64,7 +64,9 @@ public class ShovelDistributor extends MessageDistributor {
 
         super(queuesApi);
         this.shovelsApi = shovelsApi;
-        this.shovelNameToCreationTimeUTC = new HashMap<>();
+        this.shovelNameToCreationTimeUTC = ExpiringMap.builder()
+            .expiration(24, TimeUnit.HOURS)
+            .build();
         this.consumptionTargetCalculator = consumptionTargetCalculator;
         this.rabbitMQVHost = rabbitMQVHost;
         this.rabbitMQUri = String.format(

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -64,7 +65,7 @@ public class ShovelDistributor extends MessageDistributor {
 
         super(queuesApi);
         this.shovelsApi = shovelsApi;
-        this.shovelNameToCreationTimeUTC = new HashMap<>();
+        this.shovelNameToCreationTimeUTC = new ConcurrentHashMap<>();
         this.consumptionTargetCalculator = consumptionTargetCalculator;
         this.rabbitMQVHost = rabbitMQVHost;
         this.rabbitMQUri = String.format(

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelStateChecker.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelStateChecker.java
@@ -25,25 +25,25 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.concurrent.TimeUnit;
+import net.jodah.expiringmap.ExpiringMap;
 
 public final class ShovelStateChecker implements Runnable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ShovelStateChecker.class);
 
     private final RabbitManagementApi<ShovelsApi> shovelsApi;
-    private final Map<String, Instant> shovelNameToCreationTimeUTC;
+    private final Map<String, Instant> shovelNameToTimeObservedInNonRunningState;
     private final String rabbitMQVHost;
     private final long nonRunningShovelTimeoutMilliseconds;
 
     public ShovelStateChecker(
         final RabbitManagementApi<ShovelsApi> shovelsApi,
-        final Map<String, Instant> shovelNameToCreationTimeUTC,
         final String rabbitMQVHost,
         final long nonRunningShovelTimeoutMilliseconds)
     {
         this.shovelsApi = shovelsApi;
-        this.shovelNameToCreationTimeUTC = shovelNameToCreationTimeUTC;
+        this.shovelNameToTimeObservedInNonRunningState = ExpiringMap.builder().expiration(12, TimeUnit.HOURS).build();
         this.rabbitMQVHost = rabbitMQVHost;
         this.nonRunningShovelTimeoutMilliseconds = nonRunningShovelTimeoutMilliseconds;
     }
@@ -61,52 +61,38 @@ public final class ShovelStateChecker implements Runnable
 
             if (retrievedShovel.getState() != ShovelState.RUNNING) {
 
-                // Get the shovel creation time, setting it to the current time if it is not present (which may happen if this
-                // application gets restarted after the shovel is created and before it is deleted).
-                final Instant shovelCreationTimeUTC = shovelNameToCreationTimeUTC.computeIfAbsent(shovelName, s -> Instant.now());
-                final long shovelCreationTimeUTCMilliseconds = shovelCreationTimeUTC.toEpochMilli();
+                final Instant timeObservedInNonRunningState = shovelNameToTimeObservedInNonRunningState
+                    .computeIfAbsent(shovelName, s -> Instant.now());
+                final long timeObservedInNonRunningStateMilliseconds = timeObservedInNonRunningState.toEpochMilli();
 
-                final Instant timeNowUTC = Instant.now();
-                final long timeNowUTCMilliseconds = timeNowUTC.toEpochMilli();
+                final Instant timeNow = Instant.now();
+                final long timeNowMilliseconds = timeNow.toEpochMilli();
 
-                if (timeNowUTCMilliseconds - shovelCreationTimeUTCMilliseconds >= nonRunningShovelTimeoutMilliseconds) {   
-                    LOGGER.error("Shovel named {} was created at {}. The time now is {}. "
-                        + "The shovel is not yet in a 'running' state. It's current state is '{}'. "
+                if (timeNowMilliseconds - timeObservedInNonRunningStateMilliseconds >= nonRunningShovelTimeoutMilliseconds) {   
+                    LOGGER.error("Shovel named {} was observed in a non-running state at {}. The time now is {}. "
+                        + "It's current state is '{}'. "
                         + "As the non-running shovel timeout of {} milliseconds has been reached, the shovel is now going to be deleted. "
                         + "Please check the RabbitMQ logs for more details. "
                         + "Shovel creation will be attempted later if the shovel is still required.",
                                  shovelName,
-                                 shovelCreationTimeUTC,
-                                 timeNowUTC,
+                                 timeObservedInNonRunningState,
+                                 timeNow,
                                  retrievedShovel.getState().toString().toLowerCase(),
                                  nonRunningShovelTimeoutMilliseconds);                    
  
                     shovelsApi.getApi().delete(rabbitMQVHost, shovelName);
-
-                    shovelNameToCreationTimeUTC.remove(shovelName);
                 } else {
-                    LOGGER.debug("Shovel named {} was created at {}. The time now is {}. "
+                    LOGGER.debug("Shovel named {} was observed in a non-running state at {}. The time now is {}. "
                         + "The shovel is not yet in a 'running' state. It's current state is '{}'. "
                         + "However, as the non-running shovel timeout of {} milliseconds has not been reached yet, "
                         + "the shovel will not be deleted at this time.",
                                  shovelName,
-                                 shovelCreationTimeUTC,
-                                 timeNowUTC,
+                                 timeObservedInNonRunningState,
+                                 timeNow,
                                  retrievedShovel.getState().toString().toLowerCase(),
                                  nonRunningShovelTimeoutMilliseconds);
                 }
-            } else {
-                // Else the shovel is running, in which case we can remove it from the map as we don't need to keep it's creation time
-                shovelNameToCreationTimeUTC.remove(shovelName);
-            }
+            } 
         }
-
-        // Remove any shovels that have been deleted normally (e.g. automatically by RabbitMQ via src-delete-after) from the map
-        final List<String> retrievedShovelNames = retrievedShovels
-            .stream()
-            .map(RetrievedShovel::getName)
-            .collect(Collectors.toList());
-
-        shovelNameToCreationTimeUTC.entrySet().removeIf(entry -> !retrievedShovelNames.contains(entry.getKey()));
     }
 }

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelStateChecker.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelStateChecker.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public final class ShovelStateChecker implements Runnable
 {
@@ -99,5 +100,13 @@ public final class ShovelStateChecker implements Runnable
                 shovelNameToCreationTimeUTC.remove(shovelName);
             }
         }
+
+        // Remove any shovels that have been deleted normally (e.g. automatically by RabbitMQ via src-delete-after) from the map
+        final List<String> retrievedShovelNames = retrievedShovels
+            .stream()
+            .map(RetrievedShovel::getName)
+            .collect(Collectors.toList());
+
+        shovelNameToCreationTimeUTC.entrySet().removeIf(entry -> !retrievedShovelNames.contains(entry.getKey()));
     }
 }

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelStateChecker.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelStateChecker.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022-2023 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.workerframework.workermessageprioritization.redistribution.shovel;
+
+import com.github.workerframework.workermessageprioritization.rabbitmq.RabbitManagementApi;
+import com.github.workerframework.workermessageprioritization.rabbitmq.RetrievedShovel;
+import com.github.workerframework.workermessageprioritization.rabbitmq.ShovelState;
+import com.github.workerframework.workermessageprioritization.rabbitmq.ShovelsApi;
+import java.util.Date;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public final class ShovelStateChecker implements Runnable
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShovelStateChecker.class);
+
+    private final RabbitManagementApi<ShovelsApi> shovelsApi;
+    private final String rabbitMQVHost;
+    private final long nonRunningShovelTimeoutMilliseconds;
+
+    public ShovelStateChecker(
+        final RabbitManagementApi<ShovelsApi> shovelsApi,
+        final String rabbitMQVHost,
+        final long nonRunningShovelTimeoutMilliseconds)
+    {
+        this.shovelsApi = shovelsApi;
+        this.rabbitMQVHost = rabbitMQVHost;
+        this.nonRunningShovelTimeoutMilliseconds = nonRunningShovelTimeoutMilliseconds;
+    }
+
+    @Override
+    public void run()
+    {        
+        final List<RetrievedShovel> retrievedShovels = shovelsApi.getApi().getShovels();
+
+        LOGGER.debug("Read the following list of shovels from the RabbitMQ API: {}", retrievedShovels);
+
+        for (final RetrievedShovel retrievedShovel : retrievedShovels) {
+
+            if (retrievedShovel.getState() != ShovelState.RUNNING) {
+
+                final Date shovelCreationTime = retrievedShovel.getTimestamp();
+                final long shovelCreationTimeMilliseconds = shovelCreationTime.getTime();
+
+                final Date timeNow = new Date();
+                final long timeNowMilliseconds = timeNow.getTime();
+
+                if (timeNowMilliseconds - shovelCreationTimeMilliseconds >= nonRunningShovelTimeoutMilliseconds) {   
+                    LOGGER.error("Shovel named {} was created at {}. The time now is {}. "
+                        + "The shovel is not yet in a 'running' state. It's current state is '{}'. "
+                        + "As the non-running shovel timeout of {} milliseconds has been reached, the shovel is now going to be deleted. "
+                        + "Please check the RabbitMQ logs for more details. "
+                        + "Shovel creation will be attempted later if the shovel is still required.",
+                                 retrievedShovel.getName(),
+                                 shovelCreationTime,
+                                 timeNow,
+                                 retrievedShovel.getState().toString().toLowerCase(),
+                                 nonRunningShovelTimeoutMilliseconds);
+ 
+                    shovelsApi.getApi().delete(rabbitMQVHost, retrievedShovel.getName());
+                } else {
+                    LOGGER.debug("Shovel named {} was created at {}. The time now is {}. "
+                        + "The shovel is not yet in a 'running' state. It's current state is '{}'. "
+                        + "However, as the non-running shovel timeout of {} milliseconds has not been reached yet, "
+                        + "the shovel will not be deleted at this time.",
+                                 retrievedShovel.getName(),
+                                 shovelCreationTime,
+                                 timeNow,
+                                 retrievedShovel.getState().toString().toLowerCase(),
+                                 nonRunningShovelTimeoutMilliseconds);
+                }
+            }
+        }
+    }
+}

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelStateChecker.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelStateChecker.java
@@ -56,9 +56,9 @@ public final class ShovelStateChecker implements Runnable
 
         for (final RetrievedShovel retrievedShovel : retrievedShovels) {
 
-            if (retrievedShovel.getState() != ShovelState.RUNNING) {
+            final String shovelName = retrievedShovel.getName();
 
-                final String shovelName = retrievedShovel.getName();
+            if (retrievedShovel.getState() != ShovelState.RUNNING) {
 
                 // Get the shovel creation time, setting it to the current time if it is not present (which may happen if this
                 // application gets restarted after the shovel is created and before it is deleted).
@@ -94,6 +94,9 @@ public final class ShovelStateChecker implements Runnable
                                  retrievedShovel.getState().toString().toLowerCase(),
                                  nonRunningShovelTimeoutMilliseconds);
                 }
+            } else {
+                // Else the shovel is running, in which case we can remove it from the map as we don't need to keep it's creation time
+                shovelNameToCreationTimeUTC.remove(shovelName);
             }
         }
     }

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/LowLevelDistributorIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/LowLevelDistributorIT.java
@@ -65,7 +65,7 @@ public class LowLevelDistributorIT extends DistributorTestBase {
                 new EqualConsumptionTargetCalculator(new FixedTargetQueueCapacityProvider());
         final StagingTargetPairProvider stagingTargetPairProvider = new StagingTargetPairProvider();
         final LowLevelDistributor lowLevelDistributor = new LowLevelDistributor(queuesApi, connectionFactory, 
-                consumptionTargetCalculator, stagingTargetPairProvider);
+                consumptionTargetCalculator, stagingTargetPairProvider, 10000);
 
         Queue targetQueue = null;
         try(final Connection connection = connectionFactory.newConnection()) {

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelDistributorIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelDistributorIT.java
@@ -65,7 +65,7 @@ public class ShovelDistributorIT extends DistributorTestBase {
                 new EqualConsumptionTargetCalculator(new FixedTargetQueueCapacityProvider());
 
         final ShovelDistributor shovelDistributor = new ShovelDistributor(queuesApi, shovelsApi,
-                consumptionTargetCalculator);
+                consumptionTargetCalculator, System.getProperty("rabbitmq.username", "guest"), "/", 120000, 120000, 10000);
 
         Queue targetQueue = null;
         for(int attempt = 0; attempt < 10; attempt ++) {

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelStateCheckerIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelStateCheckerIT.java
@@ -26,11 +26,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
 public class ShovelStateCheckerIT extends DistributorTestBase
@@ -69,10 +66,10 @@ public class ShovelStateCheckerIT extends DistributorTestBase
         Assert.assertNotEquals("Bad shovel should not be in 'running' state", ShovelState.RUNNING, retrievedShovel.getState());
 
         // Run the ShovelStateChecker to delete the bad shovel.
-        final Map<String, Instant> shovelNameToCreationTimeUTC = new ConcurrentHashMap<>();
-        shovelNameToCreationTimeUTC.put(stagingQueueName, Instant.now().minusSeconds(5L));
-        final ShovelStateChecker shovelStateChecker = new ShovelStateChecker(shovelsApi, shovelNameToCreationTimeUTC, "/", 1L);
-        shovelStateChecker.run();
+        final ShovelStateChecker shovelStateChecker = new ShovelStateChecker(shovelsApi, "/", 1L);
+        shovelStateChecker.run(); // First run() sets the timeObservedInNonRunningState to Instant.now()
+        Thread.sleep(2000);       // Wait 2 seconds
+        shovelStateChecker.run(); // Second run() should see that the timeout of 1 millisecond has been reached, and delete the shovel
 
         // Verify the bad shovel has been deleted
         Optional<RetrievedShovel> retrievedShovelAfterDeletion;

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelStateCheckerIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelStateCheckerIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022-2023 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.workerframework.workermessageprioritization.redistribution;
+
+import com.github.workerframework.workermessageprioritization.rabbitmq.Component;
+import com.github.workerframework.workermessageprioritization.rabbitmq.RetrievedShovel;
+import com.github.workerframework.workermessageprioritization.rabbitmq.Shovel;
+import com.github.workerframework.workermessageprioritization.rabbitmq.ShovelState;
+import com.github.workerframework.workermessageprioritization.redistribution.shovel.ShovelStateChecker;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+public class ShovelStateCheckerIT extends DistributorTestBase
+{
+    @Test
+    public void nonRunningShovelShouldBeDeletedTest() throws TimeoutException, IOException, InterruptedException
+    {
+        // Create a staging queue and a target queue
+        final String targetQueueName = getUniqueTargetQueueName(TARGET_QUEUE_NAME);
+        final String stagingQueueName = getStagingQueueName(targetQueueName, T1_STAGING_QUEUE_NAME);
+
+        try (final Connection connection = connectionFactory.newConnection()) {
+            final Channel channel = connection.createChannel();
+            channel.queueDeclare(stagingQueueName, true, false, false, Collections.emptyMap());
+            channel.queueDeclare(targetQueueName, true, false, false, Collections.emptyMap());
+        }
+
+        // Create a bad shovel that never gets into a 'running' state
+        final Shovel shovel = new Shovel();
+        shovel.setAckMode("on-confirm");
+        shovel.setSrcQueue(stagingQueueName);
+        shovel.setSrcUri("amqp://BADURI");
+        shovel.setDestQueue(targetQueueName);
+        shovel.setDestUri("amqp://BADURI");
+
+        shovelsApi.getApi().putShovel("/", stagingQueueName, new Component<>("shovel", stagingQueueName, shovel));
+
+        // Verify the bad shovel is not in a 'running' state
+        final RetrievedShovel retrievedShovel = shovelsApi
+            .getApi()
+            .getShovels()
+            .stream()
+            .filter(s -> s.getName().equals(stagingQueueName))
+            .findFirst()
+            .get();
+        Assert.assertNotEquals("Bad shovel should not be in 'running' state", ShovelState.RUNNING, retrievedShovel.getState());
+
+        // Run the ShovelStateChecker to delete the bad shovel.
+        // A timeout of -10000000 is used here to allow for differences in clocks between the RabbitMQ container and where this test is
+        // running. For example, the Shovel API might return 'Wed Jan 25 17:22:50 GMT 2023', while we might call new Date() and get 
+        // 'Wed Jan 25 17:22:49 GMT 2023', which would result in 'timeNowMilliseconds - shovelCreationTimeMilliseconds' being negative,
+        // meaning the shovel never gets deleted in this test if we passed a non-negative value here.
+        final ShovelStateChecker shovelStateChecker = new ShovelStateChecker(shovelsApi, "/", -10000000);
+        shovelStateChecker.run();
+
+        // Verify the bad shovel has been deleted
+        Optional<RetrievedShovel> retrievedShovelAfterDeletion;
+        for (int attempt = 0; attempt < 10; attempt++) {
+            retrievedShovelAfterDeletion = shovelsApi
+                .getApi()
+                .getShovels()
+                .stream()
+                .filter(s -> s.getName().equals(stagingQueueName))
+                .findFirst();
+
+            if (retrievedShovelAfterDeletion.isEmpty()) {
+                // Test passed
+                return; 
+            } else {
+                // Shovel not deleted yet, wait a bit and check again
+                Thread.sleep(1000 * 10);
+            }
+        }
+
+        Assert.fail("Shovel named " + stagingQueueName + " should have been deleted but wasn't");
+    }
+}

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelStateCheckerIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelStateCheckerIT.java
@@ -28,9 +28,9 @@ import org.junit.Test;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
 public class ShovelStateCheckerIT extends DistributorTestBase
@@ -69,7 +69,7 @@ public class ShovelStateCheckerIT extends DistributorTestBase
         Assert.assertNotEquals("Bad shovel should not be in 'running' state", ShovelState.RUNNING, retrievedShovel.getState());
 
         // Run the ShovelStateChecker to delete the bad shovel.
-        final Map<String, Instant> shovelNameToCreationTimeUTC = new HashMap<>();
+        final Map<String, Instant> shovelNameToCreationTimeUTC = new ConcurrentHashMap<>();
         shovelNameToCreationTimeUTC.put(stagingQueueName, Instant.now().minusSeconds(5L));
         final ShovelStateChecker shovelStateChecker = new ShovelStateChecker(shovelsApi, shovelNameToCreationTimeUTC, "/", 1L);
         shovelStateChecker.run();

--- a/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/RabbitManagementApi.java
+++ b/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/RabbitManagementApi.java
@@ -80,6 +80,7 @@ public class RabbitManagementApi <T> {
 
         return new GsonBuilder()
             .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .setDateFormat("yyyy-MM-dd HH:mm:ss") // Format of timestamp returned by shovel API: https://www.rabbitmq.com/shovel.html
             .create();
     }
 

--- a/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/RabbitManagementApi.java
+++ b/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/RabbitManagementApi.java
@@ -80,7 +80,6 @@ public class RabbitManagementApi <T> {
 
         return new GsonBuilder()
             .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-            .setDateFormat("yyyy-MM-dd HH:mm:ss") // Format of timestamp returned by shovel API: https://www.rabbitmq.com/shovel.html
             .create();
     }
 

--- a/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/RetrievedShovel.java
+++ b/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/RetrievedShovel.java
@@ -16,11 +16,9 @@
 package com.github.workerframework.workermessageprioritization.rabbitmq;
 
 import com.google.common.base.MoreObjects;
-import java.util.Date;
 
 public class RetrievedShovel extends Shovel {
     private String name;
-    private Date timestamp;
     private ShovelState state;
 
     public String getName() {
@@ -29,14 +27,6 @@ public class RetrievedShovel extends Shovel {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public Date getTimestamp() {
-        return timestamp;
-    }
-
-    public void setTimestamp(Date timestamp) {
-        this.timestamp = timestamp;
     }
 
     public ShovelState getState() {
@@ -51,7 +41,6 @@ public class RetrievedShovel extends Shovel {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("name", name)
-            .add("timestamp", timestamp)
             .add("state", state)
             .add("ackMode", getAckMode())
             .add("srcUri", getSrcUri())

--- a/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/RetrievedShovel.java
+++ b/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/RetrievedShovel.java
@@ -15,8 +15,13 @@
  */
 package com.github.workerframework.workermessageprioritization.rabbitmq;
 
+import com.google.common.base.MoreObjects;
+import java.util.Date;
+
 public class RetrievedShovel extends Shovel {
     private String name;
+    private Date timestamp;
+    private ShovelState state;
 
     public String getName() {
         return name;
@@ -26,4 +31,34 @@ public class RetrievedShovel extends Shovel {
         this.name = name;
     }
 
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public ShovelState getState() {
+        return state;
+    }
+
+    public void setState(ShovelState state) {
+        this.state = state;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("name", name)
+            .add("timestamp", timestamp)
+            .add("state", state)
+            .add("ackMode", getAckMode())
+            .add("srcUri", getSrcUri())
+            .add("srcQueue", getSrcQueue())
+            .add("srcDeleteAfter", getSrcDeleteAfter())
+            .add("destUri", getDestUri())
+            .add("destQueue", getDestQueue())
+            .toString();
+    }
 }

--- a/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/Shovel.java
+++ b/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/Shovel.java
@@ -15,6 +15,7 @@
  */
 package com.github.workerframework.workermessageprioritization.rabbitmq;
 
+import com.google.common.base.MoreObjects;
 import com.google.gson.annotations.SerializedName;
 
 public class Shovel {
@@ -80,5 +81,16 @@ public class Shovel {
     public void setDestUri(String destUri) {
         this.destUri = destUri;
     }
-    
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("ackMode", ackMode)
+            .add("srcUri", srcUri)
+            .add("srcQueue", srcQueue)
+            .add("srcDeleteAfter", srcDeleteAfter)
+            .add("destUri", destUri)
+            .add("destQueue", destQueue)
+            .toString();
+    }
 }

--- a/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/ShovelState.java
+++ b/worker-message-prioritization-rabbitmq/src/main/java/com/github/workerframework/workermessageprioritization/rabbitmq/ShovelState.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022-2023 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.workerframework.workermessageprioritization.rabbitmq;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum ShovelState
+{
+    @SerializedName("starting")
+    STARTING,
+    @SerializedName("running")
+    RUNNING,
+    @SerializedName("terminated")
+    TERMINATED,
+}

--- a/worker-message-prioritization-rerouting/README.md
+++ b/worker-message-prioritization-rerouting/README.md
@@ -18,6 +18,6 @@ instead of to Worker B's target queue, then you would set these environment vari
     **Default**: false  
     **Description**: Only applies when `CAF_WMP_ENABLED` is true. Determines whether a worker should use the target queue's capacity when
     making a decision on whether to reroute a message. If true, a message will only be rerouted to a staging queue if the target queue
-    does not have capacity for it. If false, a message will **always** be rerouted to a staging queue, irregardless of the tarqet queue's
+    does not have capacity for it. If false, a message will **always** be rerouted to a staging queue, irregardless of the target queue's
     capacity.
 

--- a/worker-message-prioritization-rerouting/README.md
+++ b/worker-message-prioritization-rerouting/README.md
@@ -4,13 +4,20 @@
 
 ### Environment Variables
 
+These environment variables should be set on whichever worker is performing the rerouting.
+
+For example, if Worker A routes a message to Worker B, and you want Worker A to reroute the message to one of Worker B's staging queues
+instead of to Worker B's target queue, then you would set these environment variables on **Worker A**.
+
 * `CAF_WMP_ENABLED`  
     **Default**: false  
     **Description**: Determines whether a worker should reroute a message or not. If true, a message will attempt to be rerouted.
     If false, a message will not be rerouted and will be sent to the target queue rather than to a staging queue.
 
-* `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_WHEN_REROUTING`  
+* `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE`  
     **Default**: false  
-    **Description**: Determines whether a worker should use the target queue's capacity when making a decision on whether to reroute a
-    message. If true, a message will only be rerouted to a staging queue if the target queue does not have capacity for it. If false, a
-    message will always be rerouted to a staging queue. 
+    **Description**: Only applies when `CAF_WMP_ENABLED` is true. Determines whether a worker should use the target queue's capacity when
+    making a decision on whether to reroute a message. If true, a message will only be rerouted to a staging queue if the target queue
+    does not have capacity for it. If false, a message will **always** be rerouted to a staging queue, irregardless of the tarqet queue's
+    capacity.
+

--- a/worker-message-prioritization-rerouting/README.md
+++ b/worker-message-prioritization-rerouting/README.md
@@ -1,0 +1,16 @@
+# worker-message-prioritization-rerouting
+
+## Configuration
+
+### Environment Variables
+
+* `CAF_WMP_ENABLED`  
+    **Default**: false  
+    **Description**: Determines whether a worker should reroute a message or not. If true, a message will attempt to be rerouted.
+    If false, a message will not be rerouted and will be sent to the target queue rather than to a staging queue.
+
+* `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_WHEN_REROUTING`  
+    **Default**: false  
+    **Description**: Determines whether a worker should use the target queue's capacity when making a decision on whether to reroute a
+    message. If true, a message will only be rerouted to a staging queue if the target queue does not have capacity for it. If false, a
+    message will always be rerouted to a staging queue. 

--- a/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/MessageRouterSingleton.java
+++ b/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/MessageRouterSingleton.java
@@ -67,7 +67,7 @@ public class MessageRouterSingleton {
             
             final StagingQueueCreator stagingQueueCreator = new StagingQueueCreator(connection.createChannel());
 
-            final RerouteDecider rerouteDecider = Boolean.valueOf(System.getenv("CAF_WMP_USE_TARGET_QUEUE_CAPACITY_WHEN_REROUTING"))
+            final RerouteDecider rerouteDecider = Boolean.valueOf(System.getenv("CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE"))
                 ? new TargetQueueCapacityRerouteDecider()
                 : new AlwaysRerouteDecider();
 

--- a/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/MessageRouterSingleton.java
+++ b/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/MessageRouterSingleton.java
@@ -42,11 +42,6 @@ public class MessageRouterSingleton {
         }
 
         initAttempted = true;
-
-        if(!Boolean.parseBoolean(System.getenv("CAF_WMP_ENABLED"))) {
-            LOGGER.error("Ignored WMP init request, CAF_WMP_ENABLED evaluated to false.");
-            return;
-        }
         
         try {
 

--- a/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/MessageRouterSingleton.java
+++ b/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/MessageRouterSingleton.java
@@ -67,9 +67,10 @@ public class MessageRouterSingleton {
             
             final StagingQueueCreator stagingQueueCreator = new StagingQueueCreator(connection.createChannel());
 
-            final RerouteDecider rerouteDecider = Boolean.valueOf(System.getenv("CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE"))
-                ? new TargetQueueCapacityRerouteDecider()
-                : new AlwaysRerouteDecider();
+            final RerouteDecider rerouteDecider =
+                    Boolean.parseBoolean(System.getenv("CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE"))
+                            ? new TargetQueueCapacityRerouteDecider()
+                            : new AlwaysRerouteDecider();
 
             LOGGER.debug("Using {} to decide whether to reroute messages", rerouteDecider.getClass().getName());
 

--- a/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/reroutedeciders/AlwaysRerouteDecider.java
+++ b/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/reroutedeciders/AlwaysRerouteDecider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022-2023 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.workerframework.workermessageprioritization.rerouting.reroutedeciders;
+
+import com.github.workerframework.workermessageprioritization.rabbitmq.Queue;
+import com.github.workerframework.workermessageprioritization.targetcapacitycalculators.TargetQueueCapacityProvider;
+
+/**
+ * A {@link RerouteDecider} that always reroutes a message to a staging queue.
+ */
+public class AlwaysRerouteDecider implements RerouteDecider
+{
+    @Override
+    public boolean shouldReroute(final Queue targetQueue, final TargetQueueCapacityProvider targetQueueCapacityProvider)
+    {
+        return true;
+    }
+}

--- a/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/reroutedeciders/RerouteDecider.java
+++ b/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/reroutedeciders/RerouteDecider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2023 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.workerframework.workermessageprioritization.rerouting.reroutedeciders;
+
+import com.github.workerframework.workermessageprioritization.rabbitmq.Queue;
+import com.github.workerframework.workermessageprioritization.targetcapacitycalculators.TargetQueueCapacityProvider;
+
+/**
+ * Decides whether a message should be rerouted to a staging queue or not.
+ */
+public interface RerouteDecider
+{
+    boolean shouldReroute(final Queue targetQueue, final TargetQueueCapacityProvider targetQueueCapacityProvider);
+}

--- a/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/reroutedeciders/TargetQueueCapacityRerouteDecider.java
+++ b/worker-message-prioritization-rerouting/src/main/java/com/github/workerframework/workermessageprioritization/rerouting/reroutedeciders/TargetQueueCapacityRerouteDecider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022-2023 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.workerframework.workermessageprioritization.rerouting.reroutedeciders;
+
+import com.github.workerframework.workermessageprioritization.rabbitmq.Queue;
+import com.github.workerframework.workermessageprioritization.targetcapacitycalculators.TargetQueueCapacityProvider;
+
+/**
+ * A {@link RerouteDecider} that reroutes a message to a staging queue if the target queue does not have capacity for it.
+ */
+public class TargetQueueCapacityRerouteDecider implements RerouteDecider
+{
+    @Override
+    public boolean shouldReroute(final Queue targetQueue, final TargetQueueCapacityProvider targetQueueCapacityProvider)
+    {
+        return targetQueue.getMessages() >= targetQueueCapacityProvider.get(targetQueue);
+    }
+}

--- a/worker-message-prioritization-rerouting/src/test/java/com/github/workerframework/workermessageprioritization/rerouting/MessageRouterTests.java
+++ b/worker-message-prioritization-rerouting/src/test/java/com/github/workerframework/workermessageprioritization/rerouting/MessageRouterTests.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import com.github.workerframework.workermessageprioritization.rerouting.reroutedeciders.RerouteDecider;
 
 public class MessageRouterTests {
     
@@ -43,10 +44,12 @@ public class MessageRouterTests {
         when(queuesApi.getQueue(anyString(), anyString())).thenReturn(mockQueue);
         when(queuesApiWrapper.getApi()).thenReturn(queuesApi);
         
-        final TargetQueueCapacityProvider targetQueueCapacityProvider = mock(TargetQueueCapacityProvider.class) ;
+        final TargetQueueCapacityProvider targetQueueCapacityProvider = mock(TargetQueueCapacityProvider.class);
+        final RerouteDecider rerouteDecider = mock(RerouteDecider.class);
+        when(rerouteDecider.shouldReroute(mockQueue, targetQueueCapacityProvider)).thenReturn(true);
         final StagingQueueCreator stagingQueueCreator = mock(StagingQueueCreator.class);
         final MessageRouter messageRouter = new MessageRouter(queuesApiWrapper,  "/", stagingQueueCreator, 
-                targetQueueCapacityProvider);
+                rerouteDecider, targetQueueCapacityProvider);
 
         final Document document = mock(Document.class);
         when(document.getCustomData("tenantId")).thenReturn("poc-tenant");


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=616155

**Distributor**
- Set `src-delete-after` to correct value
- Made RabbitMQ vhost configurable
- Made distributor sleep/run interval configurable
- Added task to check for + delete shovels in a bad state
- Added `ShovelApplication` and made it the main class in the container

**Router**
- Remove check for CAF_WMP_ENABLED, done in workflow-control.js now
- Added `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE` to control how we reroute. This allows us to always reroute to a staging queue by setting this to false (default).