### PR TITLE
Update official-build.props to use Java 8 build image

### DIFF
--- a/official-build.props
+++ b/official-build.props
@@ -1,1 +1,1 @@
-SEPG_BUILD_ENV_IMAGE=cafapi/buildenv-jdk11:1.0.0
+SEPG_BUILD_ENV_IMAGE=cafapi/opensuse-jdk8-maven:1.0.0


### PR DESCRIPTION
I believe this change was missed when we updated this repo from Java 11 to Java 8 when we moved it to opensource.:

https://github.com/WorkerFramework/worker-message-prioritization/commit/6e973ed20b3b377aeaad1a6ddf1176ae69c96059#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R48