### PR TITLE
616155: Recreate terminated shovels if required

### DIFF
--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
@@ -125,14 +125,12 @@ public class ShovelDistributor extends MessageDistributor {
                         final long maxNumMessagesToConsumeFromStagingQueue = queueConsumptionTarget.getValue();
                         final long srcDeleteAfter = Math.min(numMessagesInStagingQueue, maxNumMessagesToConsumeFromStagingQueue);
 
-                        final String targetQueue = distributorWorkItem.getTargetQueue().getName();
-
                         final Shovel shovel = new Shovel();
                         shovel.setSrcDeleteAfter(srcDeleteAfter);
                         shovel.setAckMode(ACK_MODE);
                         shovel.setSrcQueue(shovelName);
                         shovel.setSrcUri(rabbitMQUri);
-                        shovel.setDestQueue(targetQueue);
+                        shovel.setDestQueue(distributorWorkItem.getTargetQueue().getName());
                         shovel.setDestUri(rabbitMQUri);
 
                         LOGGER.info("(Re)creating shovel named {} with properties {} to consume {} messages",

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
@@ -112,8 +112,7 @@ public class ShovelDistributor extends MessageDistributor {
                     final String shovelName = queueConsumptionTarget.getKey().getName();
 
                     final boolean nonTerminatedShovelExists = retrievedShovels.stream()
-                            .filter(retrievedShovel -> retrievedShovel.getState() != ShovelState.TERMINATED)
-                            .anyMatch(s -> s.getName().endsWith(shovelName));
+                            .anyMatch(s -> (s.getState() != ShovelState.TERMINATED) && (s.getName().endsWith(shovelName)));
 
                     if (nonTerminatedShovelExists) {
                         LOGGER.info("Non-terminated shovel {} already exists, ignoring.", shovelName);

--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/shovel/ShovelDistributor.java
@@ -15,6 +15,7 @@
  */
 package com.github.workerframework.workermessageprioritization.redistribution.shovel;
 
+import com.github.workerframework.workermessageprioritization.rabbitmq.ShovelState;
 import com.github.workerframework.workermessageprioritization.redistribution.MessageDistributor;
 import com.github.workerframework.workermessageprioritization.redistribution.consumption.ConsumptionTargetCalculator;
 import com.github.workerframework.workermessageprioritization.rabbitmq.Component;
@@ -107,15 +108,15 @@ public class ShovelDistributor extends MessageDistributor {
             }
             else {
                 for(final Map.Entry<Queue, Long> queueConsumptionTarget: consumptionTarget.entrySet()) {
-//                    if(sourceQueue.getMessages() == 0) {
-//                        LOGGER.info("Source queue '{}' has no messages, ignoring.", 
-//                                distributorWorkItem.getTargetQueue().getName());
-//
-//                        continue;
-//                    }
-                    if(retrievedShovels.stream().anyMatch(s -> s.getName()
-                            .endsWith(queueConsumptionTarget.getKey().getName()))) {
-                        LOGGER.info("Shovel {} already exists, ignoring.", queueConsumptionTarget.getKey().getName());
+
+                    final String shovelName = queueConsumptionTarget.getKey().getName();
+
+                    final boolean nonTerminatedShovelExists = retrievedShovels.stream()
+                            .filter(retrievedShovel -> retrievedShovel.getState() != ShovelState.TERMINATED)
+                            .anyMatch(s -> s.getName().endsWith(shovelName));
+
+                    if (nonTerminatedShovelExists) {
+                        LOGGER.info("Non-terminated shovel {} already exists, ignoring.", shovelName);
                     } else {
                         // Delete this shovel after all the messages in the staging queue have been consumed OR we have reached the
                         // maximum amount of messages we are allowed to consume from the staging queue (whichever is lower).
@@ -123,26 +124,25 @@ public class ShovelDistributor extends MessageDistributor {
                         final long numMessagesInStagingQueue = queueConsumptionTarget.getKey().getMessages();
                         final long maxNumMessagesToConsumeFromStagingQueue = queueConsumptionTarget.getValue();
                         final long srcDeleteAfter = Math.min(numMessagesInStagingQueue, maxNumMessagesToConsumeFromStagingQueue);
- 
-                        final String stagingQueue = queueConsumptionTarget.getKey().getName();
+
                         final String targetQueue = distributorWorkItem.getTargetQueue().getName();
 
                         final Shovel shovel = new Shovel();
                         shovel.setSrcDeleteAfter(srcDeleteAfter);
                         shovel.setAckMode(ACK_MODE);
-                        shovel.setSrcQueue(stagingQueue);
+                        shovel.setSrcQueue(shovelName);
                         shovel.setSrcUri(rabbitMQUri);
                         shovel.setDestQueue(targetQueue);
                         shovel.setDestUri(rabbitMQUri);
 
-                        LOGGER.info("Creating shovel named {} with properties {} to consume {} messages",
-                                    stagingQueue,
-                                    shovel,
-                                    srcDeleteAfter);
+                        LOGGER.info("(Re)creating shovel named {} with properties {} to consume {} messages",
+                                shovelName,
+                                shovel,
+                                srcDeleteAfter);
 
-                        shovelsApi.getApi().putShovel(rabbitMQVHost, stagingQueue,
+                        shovelsApi.getApi().putShovel(rabbitMQVHost, shovelName,
                                                       new Component<>("shovel",
-                                                                      stagingQueue,
+                                                                      shovelName,
                                                                       shovel));
                     }
                 }


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=616155

A shovel may become stuck in a 'terminated' state. If it does, it is not possible to delete or restart the shovel, meaning messages will get stuck on staging queues.

However, it is possible to recreate the shovel if it is in a 'terminated' state, which is what we're doing here.