### PR TITLE
663082: Fix random twoStagingQueuesTest failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
           <artifactId>expiringmap</artifactId>
           <version>0.5.10</version>
       </dependency>
+      <dependency>
+          <groupId>org.awaitility</groupId>
+          <artifactId>awaitility</artifactId>
+          <version>4.2.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/worker-message-prioritization-distribution/pom.xml
+++ b/worker-message-prioritization-distribution/pom.xml
@@ -87,6 +87,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorTestBase.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorTestBase.java
@@ -15,14 +15,11 @@
  */
 package com.github.workerframework.workermessageprioritization.redistribution;
 
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 
-import com.github.workerframework.workermessageprioritization.rabbitmq.RetrievedShovel;
-import com.github.workerframework.workermessageprioritization.redistribution.shovel.NodeSpecificRabbitMqMgmtUrlBuilder;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorTestBase.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorTestBase.java
@@ -15,10 +15,13 @@
  */
 package com.github.workerframework.workermessageprioritization.redistribution;
 
+import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 
+import com.github.workerframework.workermessageprioritization.rabbitmq.RetrievedShovel;
 import com.github.workerframework.workermessageprioritization.redistribution.shovel.NodeSpecificRabbitMqMgmtUrlBuilder;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -102,5 +105,21 @@ public class DistributorTestBase {
                         return shovelsApi;
                     }
                 });
+    }
+
+    protected Callable<Boolean> queueContainsNumMessages(final String queueName, final int numMessages)
+    {
+        return () -> queuesApi.getApi().getQueue("/", queueName).getMessages() == numMessages;
+    }
+
+    protected Callable<Boolean> shovelIsDeleted(final String shovelName)
+    {
+        return () -> !shovelsApi
+                .getApi()
+                .getShovels()
+                .stream()
+                .filter(s -> s.getName().equals(shovelName))
+                .findFirst()
+                .isPresent();
     }
 }

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/LowLevelDistributorIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/LowLevelDistributorIT.java
@@ -15,11 +15,13 @@
  */
 package com.github.workerframework.workermessageprioritization.redistribution;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
 import com.github.workerframework.workermessageprioritization.redistribution.consumption.ConsumptionTargetCalculator;
 import com.github.workerframework.workermessageprioritization.redistribution.consumption.EqualConsumptionTargetCalculator;
 import com.github.workerframework.workermessageprioritization.redistribution.lowlevel.LowLevelDistributor;
 import com.github.workerframework.workermessageprioritization.redistribution.lowlevel.StagingTargetPairProvider;
-import com.github.workerframework.workermessageprioritization.rabbitmq.Queue;
 import com.github.workerframework.workermessageprioritization.targetcapacitycalculators.FixedTargetQueueCapacityProvider;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
@@ -29,6 +31,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.TimeoutException;
 
@@ -58,7 +61,16 @@ public class LowLevelDistributorIT extends DistributorTestBase {
             
             channel.basicPublish("", stagingQueue1Name, properties, body.getBytes(StandardCharsets.UTF_8));
             channel.basicPublish("", stagingQueue2Name, properties, body.getBytes(StandardCharsets.UTF_8));
-            
+
+            await().alias(String.format("Waiting for 1st staging queue named %s to contain 1 message", stagingQueue1Name))
+                    .atMost(100, SECONDS)
+                    .pollInterval(Duration.ofSeconds(1))
+                    .until(queueContainsNumMessages(stagingQueue1Name, 1));
+
+            await().alias(String.format("Waiting for 2nd staging queue named %s to contain 1 message", stagingQueue2Name))
+                    .atMost(100, SECONDS)
+                    .pollInterval(Duration.ofSeconds(1))
+                    .until(queueContainsNumMessages(stagingQueue2Name, 1));
         }
         
         final ConsumptionTargetCalculator consumptionTargetCalculator = 
@@ -67,25 +79,16 @@ public class LowLevelDistributorIT extends DistributorTestBase {
         final LowLevelDistributor lowLevelDistributor = new LowLevelDistributor(queuesApi, connectionFactory, 
                 consumptionTargetCalculator, stagingTargetPairProvider, 10000);
 
-        Queue targetQueue = null;
-        try(final Connection connection = connectionFactory.newConnection()) {
-            for(int attempt = 0; attempt < 10; attempt ++) {
-                lowLevelDistributor.runOnce(connection);
+        try (final Connection connection = connectionFactory.newConnection()) {
+            lowLevelDistributor.runOnce(connection);
 
-                targetQueue = queuesApi.getApi().getQueue("/", targetQueueName);
-                if(targetQueue.getMessages() > 0) {
-                    break;
-                }
-
-                Thread.sleep(1000 * 10);
-            }
+            await().alias(String.format("Waiting for target queue named %s to contain 2 messages", targetQueueName))
+                    .atMost(100, SECONDS)
+                    .pollInterval(Duration.ofSeconds(1))
+                    .until(queueContainsNumMessages(targetQueueName, 2));
         }
 
-        Assert.assertNotNull("Target queue was not found via REST API", targetQueue);
-        final Queue stagingQueue1 = queuesApi.getApi().getQueue("/", stagingQueue1Name);
-        final Queue stagingQueue2 = queuesApi.getApi().getQueue("/", stagingQueue2Name);
-        Assert.assertEquals("Two staged messages should be on target queue", 2L, targetQueue.getMessages());
-        Assert.assertEquals("1st Staging queue should be empty", 0L, stagingQueue1.getMessages());
-        Assert.assertEquals("2n Staging queue should be empty", 0L, stagingQueue2.getMessages());
+        Assert.assertEquals("1st Staging queue should be empty", 0L, queuesApi.getApi().getQueue("/", stagingQueue1Name).getMessages());
+        Assert.assertEquals("2nd Staging queue should be empty", 0L, queuesApi.getApi().getQueue("/", stagingQueue2Name).getMessages());
     }
 }

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/NonRunningShovelCheckerIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/NonRunningShovelCheckerIT.java
@@ -15,6 +15,9 @@
  */
 package com.github.workerframework.workermessageprioritization.redistribution;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
 import com.github.workerframework.workermessageprioritization.rabbitmq.Component;
 import com.github.workerframework.workermessageprioritization.rabbitmq.RetrievedShovel;
 import com.github.workerframework.workermessageprioritization.rabbitmq.Shovel;
@@ -26,8 +29,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -81,26 +84,10 @@ public class NonRunningShovelCheckerIT extends DistributorTestBase
                 TimeUnit.MILLISECONDS);
 
         try {
-            // Verify the bad shovel has been deleted
-            Optional<RetrievedShovel> retrievedShovelAfterDeletion;
-            for (int attempt = 0; attempt < 10; attempt++) {
-                retrievedShovelAfterDeletion = shovelsApi
-                        .getApi()
-                        .getShovels()
-                        .stream()
-                        .filter(s -> s.getName().equals(stagingQueueName))
-                        .findFirst();
-
-                if (!retrievedShovelAfterDeletion.isPresent()) {
-                    // Test passed
-                    return;
-                } else {
-                    // Shovel not deleted yet, wait a bit and check again
-                    Thread.sleep(2000);
-                }
-            }
-
-            Assert.fail("Shovel named " + stagingQueueName + " should have been deleted but wasn't");
+            await().alias(String.format("Waiting for shovel named %s to be deleted", stagingQueueName))
+                    .atMost(100, SECONDS)
+                    .pollInterval(Duration.ofSeconds(1))
+                    .until(shovelIsDeleted(stagingQueueName));
         } finally {
             nonRunningShovelCheckerExecutorService.shutdownNow();
         }


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=663082

- Wait until messages are on staging queues before proceeding with rest of test
- Use https://github.com/awaitility/awaitility to simplify waiting/polling in tests