### PR TITLE
687022: Fix random test failure

### DIFF
--- a/worker-message-prioritization-distribution-container/pom.xml
+++ b/worker-message-prioritization-distribution-container/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/worker-message-prioritization-distribution-container/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorIT.java
+++ b/worker-message-prioritization-distribution-container/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorIT.java
@@ -21,7 +21,6 @@ import static org.awaitility.Awaitility.await;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -58,24 +57,21 @@ public final class DistributorIT extends DistributorTestBase {
 
             channel.basicPublish("", stagingQueue1Name, properties, body.getBytes(StandardCharsets.UTF_8));
             channel.basicPublish("", stagingQueue2Name, properties, body.getBytes(StandardCharsets.UTF_8));
-
-            await().alias(String.format("Waiting for 1st staging queue named %s to contain 1 message", stagingQueue1Name))
-                    .atMost(100, SECONDS)
-                    .pollInterval(Duration.ofSeconds(1))
-                    .until(queueContainsNumMessages(stagingQueue1Name, 1));
-
-            await().alias(String.format("Waiting for 2nd staging queue named %s to contain 1 message", stagingQueue2Name))
-                    .atMost(100, SECONDS)
-                    .pollInterval(Duration.ofSeconds(1))
-                    .until(queueContainsNumMessages(stagingQueue2Name, 1));
         }
 
-        await().alias(String.format("Waiting for target queue named %s to contain 2 messages", targetQueueName))
+        await().alias(String.format("Target queue named %s should contain 2 message", targetQueueName))
                 .atMost(100, SECONDS)
                 .pollInterval(Duration.ofSeconds(1))
                 .until(queueContainsNumMessages(targetQueueName, 2));
 
-        Assert.assertEquals("1st Staging queue should be empty", 0L, queuesApi.getApi().getQueue("/", stagingQueue1Name).getMessages());
-        Assert.assertEquals("2nd Staging queue should be empty", 0L, queuesApi.getApi().getQueue("/", stagingQueue2Name).getMessages());
+        await().alias(String.format("1st staging queue named %s should be empty", stagingQueue1Name))
+                .atMost(100, SECONDS)
+                .pollInterval(Duration.ofSeconds(1))
+                .until(queueContainsNumMessages(stagingQueue1Name, 0));
+
+        await().alias(String.format("2nd staging queue named %s should be empty", stagingQueue2Name))
+                .atMost(100, SECONDS)
+                .pollInterval(Duration.ofSeconds(1))
+                .until(queueContainsNumMessages(stagingQueue2Name, 0));
     }
 }

--- a/worker-message-prioritization-distribution-container/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorIT.java
+++ b/worker-message-prioritization-distribution-container/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorIT.java
@@ -59,17 +59,17 @@ public final class DistributorIT extends DistributorTestBase {
             channel.basicPublish("", stagingQueue2Name, properties, body.getBytes(StandardCharsets.UTF_8));
         }
 
-        await().alias(String.format("Target queue named %s should contain 2 message", targetQueueName))
+        await().alias(String.format("Waiting for target queue named %s to contain 2 message", targetQueueName))
                 .atMost(100, SECONDS)
                 .pollInterval(Duration.ofSeconds(1))
                 .until(queueContainsNumMessages(targetQueueName, 2));
 
-        await().alias(String.format("1st staging queue named %s should be empty", stagingQueue1Name))
+        await().alias(String.format("Waiting for 1st staging queue named %s to contain 0 messages", stagingQueue1Name))
                 .atMost(100, SECONDS)
                 .pollInterval(Duration.ofSeconds(1))
                 .until(queueContainsNumMessages(stagingQueue1Name, 0));
 
-        await().alias(String.format("2nd staging queue named %s should be empty", stagingQueue2Name))
+        await().alias(String.format("Waiting for 2nd staging queue named %s to contain 0 messages", stagingQueue2Name))
                 .atMost(100, SECONDS)
                 .pollInterval(Duration.ofSeconds(1))
                 .until(queueContainsNumMessages(stagingQueue2Name, 0));

--- a/worker-message-prioritization-distribution-container/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorTestBase.java
+++ b/worker-message-prioritization-distribution-container/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/DistributorTestBase.java
@@ -15,6 +15,8 @@
  */
 package com.github.workerframework.workermessageprioritization.redistribution;
 
+import java.util.concurrent.Callable;
+
 import com.google.gson.Gson;
 import com.github.workerframework.workermessageprioritization.rabbitmq.QueuesApi;
 import com.github.workerframework.workermessageprioritization.rabbitmq.RabbitManagementApi;
@@ -60,5 +62,9 @@ public class DistributorTestBase {
 
     protected String getStagingQueueName(final String targetQueueName, final String stagingQueueName) {
         return targetQueueName + MessageDistributor.LOAD_BALANCED_INDICATOR + stagingQueueName;
+    }
+
+    protected Callable<Boolean> queueContainsNumMessages(final String queueName, final int numMessages) {
+        return () -> queuesApi.getApi().getQueue("/", queueName).getMessages() == numMessages;
     }
 }

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/LowLevelDistributorIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/LowLevelDistributorIT.java
@@ -26,7 +26,6 @@ import com.github.workerframework.workermessageprioritization.targetcapacitycalc
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -88,7 +87,14 @@ public class LowLevelDistributorIT extends DistributorTestBase {
                     .until(queueContainsNumMessages(targetQueueName, 2));
         }
 
-        Assert.assertEquals("1st Staging queue should be empty", 0L, queuesApi.getApi().getQueue("/", stagingQueue1Name).getMessages());
-        Assert.assertEquals("2nd Staging queue should be empty", 0L, queuesApi.getApi().getQueue("/", stagingQueue2Name).getMessages());
+        await().alias(String.format("Waiting for 1st staging queue named %s to contain 0 messages", stagingQueue1Name))
+                .atMost(100, SECONDS)
+                .pollInterval(Duration.ofSeconds(1))
+                .until(queueContainsNumMessages(stagingQueue1Name, 0));
+
+        await().alias(String.format("Waiting for 2nd staging queue named %s to contain 0 messages", stagingQueue2Name))
+                .atMost(100, SECONDS)
+                .pollInterval(Duration.ofSeconds(1))
+                .until(queueContainsNumMessages(stagingQueue2Name, 0));
     }
 }

--- a/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelDistributorIT.java
+++ b/worker-message-prioritization-distribution/src/test/java/com/github/workerframework/workermessageprioritization/redistribution/ShovelDistributorIT.java
@@ -26,7 +26,6 @@ import com.rabbitmq.client.AMQP;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -98,7 +97,14 @@ public class ShovelDistributorIT extends DistributorTestBase {
                 .pollInterval(Duration.ofSeconds(1))
                 .until(queueContainsNumMessages(targetQueueName, 2));
 
-        Assert.assertEquals("1st Staging queue should be empty", 0L, queuesApi.getApi().getQueue("/", stagingQueue1Name).getMessages());
-        Assert.assertEquals("2nd Staging queue should be empty", 0L, queuesApi.getApi().getQueue("/", stagingQueue2Name).getMessages());
+        await().alias(String.format("Waiting for 1st staging queue named %s to contain 0 messages", stagingQueue1Name))
+                .atMost(100, SECONDS)
+                .pollInterval(Duration.ofSeconds(1))
+                .until(queueContainsNumMessages(stagingQueue1Name, 0));
+
+        await().alias(String.format("Waiting for 2nd staging queue named %s to contain 0 messages", stagingQueue2Name))
+                .atMost(100, SECONDS)
+                .pollInterval(Duration.ofSeconds(1))
+                .until(queueContainsNumMessages(stagingQueue2Name, 0));
     }
 }


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=687022

- This test was missed in the original PR: https://github.com/WorkerFramework/worker-message-prioritization/pull/24
- Added additional polls to check for empty staging queues in other tests as well, I noticed that the original non-polling assert sometimes failed due to a message still on the staging queue, so giving the staging queues a bit of time to become empty