### PR TITLE
US361030: Downgrade to Jersey 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,22 +412,22 @@
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-client</artifactId>
-        <version>3.1.5</version>
+        <version>3.0.12</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-common</artifactId>
-        <version>3.1.5</version>
+        <version>3.0.12</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.inject</groupId>
         <artifactId>jersey-hk2</artifactId>
-        <version>3.1.5</version>
+        <version>3.0.12</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-gson</artifactId>
-        <version>3.1.5</version>
+        <version>3.0.12</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=361030

All the workers use 3.0 so it makes more sense to use this version.