### PR TITLE
I902105: Fix Maven artifacts not getting deployed

### DIFF
--- a/worker-message-prioritization-distribution-container/pom.xml
+++ b/worker-message-prioritization-distribution-container/pom.xml
@@ -30,8 +30,6 @@
     <url>http://maven.apache.org</url> 
 
     <properties>
-        <maven.install.skip>true</maven.install.skip>
-        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <dockerHubOrganization>workerframework</dockerHubOrganization>
         <dockerWorkerFrameworkOrg>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerWorkerFrameworkOrg>
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=902105

Was noticed as part of I902105 however, is a result of [dropping the rerouting library](https://github.com/WorkerFramework/worker-message-prioritization/commit/95e3093177cb7f3df2501c1db9806a1f4f26045b).