### PR TITLE
US1009117: Copy headers when publishing

### DIFF
--- a/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/lowlevel/StagingQueueTargetQueuePair.java
+++ b/worker-message-prioritization-distribution/src/main/java/com/github/workerframework/workermessageprioritization/redistribution/lowlevel/StagingQueueTargetQueuePair.java
@@ -152,6 +152,7 @@ public class StagingQueueTargetQueuePair {
 
 
         AMQP.BasicProperties basicProperties = new AMQP.BasicProperties.Builder()
+                .headers(properties.getHeaders())
                 .contentType(properties.getContentType())
                 .deliveryMode(properties.getDeliveryMode())
                 .build();


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1009117

New headers that were added to support message minimization were being lost when passing through message prioritization. 