### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/worker-message-prioritization-target-capacity-calculators/pom.xml
+++ b/worker-message-prioritization-target-capacity-calculators/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>worker-message-prioritization-target-capacity-calculators</artifactId>
+    <name>worker-message-prioritization-target-capacity-calculators</name>
     
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210