### PR TITLE
D1048051: Read CAF_WORKER_JAVA_OPTS at container runtime not build time

### DIFF
--- a/worker-message-prioritization-distribution-container/pom.xml
+++ b/worker-message-prioritization-distribution-container/pom.xml
@@ -221,13 +221,9 @@
                                     <cmd>/maven/healthcheck/healthcheck.sh || exit 1</cmd>
                                 </healthCheck>
                                 <entryPoint>
-                                    <arg>/tini</arg>
-                                    <arg>--</arg>
-                                    <arg>/startup/startup.sh</arg>
-                                    <arg>java</arg>
-                                    <arg>${env.CAF_WORKER_JAVA_OPTS}</arg>
-                                    <arg>-jar</arg>
-                                    <arg>/maven/worker-message-prioritization-distribution-${project.version}.jar</arg>
+                                    <arg>/bin/sh</arg>
+                                    <arg>-c</arg>
+                                    <arg>exec /tini -- /startup/startup.sh java ${CAF_WORKER_JAVA_OPTS} -jar /maven/worker-message-prioritization-distribution-${project.version}.jar</arg>
                                 </entryPoint>
                                 <assembly>
                                     <mode>tar</mode>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1048051